### PR TITLE
Add support for net metering mode responses from WEM3080T meter.

### DIFF
--- a/iammeter/power_meter.py
+++ b/iammeter/power_meter.py
@@ -242,9 +242,18 @@ class WEM3080T(IamMeter):
         'Power_C':                  (2,2, 'W'),
         'ImportEnergy_C':           (2,3, 'kWh'),
 
-        'ExportGrid_C':             (2,4, 'kWh'),
-        'Frequency_C':              (2,5, 'Hz'),
-        'PF_C':                     (2,6, ''),
+        'ExportGrid_C':             (2, 4, 'kWh'),
+        'Frequency_C':              (2, 5, 'Hz'),
+        'PF_C':                     (2, 6, ''),
+
+        'Voltage_Net':              (3, 0, 'V'),
+        # 'Current_Net':             (3,1, 'A'), # Second item in array is constant 0.0, net mode doesn't report net current.
+        'Power_Net':                (3, 2, 'W'),
+        'ImportEnergy_Net':         (3, 3, 'kWh'),
+
+        'ExportGrid_Net':           (3, 4, 'kWh'),
+        'Frequency_Net':            (3, 5, 'Hz'),
+        'PF_Net':                   (3, 6, ''),
     }
     
     @staticmethod


### PR DESCRIPTION
Hi, as mentioned on the iammeter community forum (https://imeter.club/topic/178). This PR contains a small patch to read the outputs when Net meter mode is active.

This was required so that my WEM3080T could report 3 phase net energy import and export values to home assistant.

